### PR TITLE
Fix for unwanted scaledown if pod has 0 CPU usage

### DIFF
--- a/deploy/scaler-deployment.yaml
+++ b/deploy/scaler-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: scaler-sa
       containers:
         - name: scaler
-          image: denisjd/simple-scaler:v3.0
+          image: denisjd/simple-scaler:v3.1
           args:
             - -prometheus-url=http://prometheus
           resources:


### PR DESCRIPTION
Pods can have 0 CPU usage for sometime before being added to a service (for serving traffic) and after removing from service endpoint.
This triggers a unwanted scaledown if any pod has 0 CPU usage